### PR TITLE
Remove 'font-family' style property in LayoutCardGrid

### DIFF
--- a/src/components/CardGrid/CardGrid.Styled.jsx
+++ b/src/components/CardGrid/CardGrid.Styled.jsx
@@ -33,7 +33,6 @@ export const LayoutCardGrid = styled.div`
           border-radius: 50px;
           font-weight: 500;
           color: #fff;
-          font-family: "ROBOTO" !important;
         }
       }
       .image-container {


### PR DESCRIPTION
fixes #22
Hello, found this repository in github-help-wanted.com and saw the `help-wanted` tag.

I've removed the 'font-family' style property as it is trying to use the "Roboto", which is not being loaded from Google Fonts.

